### PR TITLE
Make it a configuration option which ACME authority is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Thirdly, you should decide which challenge mode you want to use with acertmgr
     This starts a webserver to solve the challenges, which can be used standalone or together with an existing webserver that forwards request to a specified local port.
 
 Finally, you need to setup the configuration files, as shown in the next section.
+While testing, you can use the acme-staging authority instead, so you avoid issuing too many certificates.
 
 Configuration
 -------------
@@ -50,6 +51,8 @@ mode: webdir
 #mode: standalone
 #port: 13135
 webdir: /var/www/acme-challenge/
+authority: "https://acme-v01.api.letsencrypt.org"
+#authority: "https://acme-staging.api.letsencrypt.org"
 
 defaults:
   cafile: /etc/acme/lets-encrypt-x3-cross-signed.pem

--- a/acertmgr.py
+++ b/acertmgr.py
@@ -96,7 +96,7 @@ def cert_get(domains, settings):
 		key = key_fd.read()
 		key_fd.close()
 		cr = acertmgr_ssl.cert_request(domains.split(), key)
-		crt = acertmgr_ssl.get_crt_from_csr(acc_file, cr, domains.split(), challenge_dir)
+		crt = acertmgr_ssl.get_crt_from_csr(acc_file, cr, domains.split(), challenge_dir, settings['authority'])
 		with open(crt_file, "w") as crt_fd:
 			crt_fd.write(crt)
 

--- a/acertmgr.py
+++ b/acertmgr.py
@@ -107,8 +107,8 @@ def cert_get(domains, settings):
 
 	finally:
 		if settings['mode'] == 'standalone':
-			os.chdir(current_dir)
 			server.stop()
+			os.chdir(current_dir)
 		os.remove(csr_file)
 		os.remove(crt_file)
 

--- a/acertmgr_ssl.py
+++ b/acertmgr_ssl.py
@@ -22,9 +22,6 @@ try:
 except ImportError:
 	from urllib2 import urlopen # Python 2
 
-DEFAULT_CA = "https://acme-staging.api.letsencrypt.org"
-#DEFAULT_CA = "https://acme-v01.api.letsencrypt.org"
-
 # @brief retrieve notBefore and notAfter dates of a certificate file
 # @param cert_file the path to the certificate
 # @return the tuple of dates: (notBefore, notAfter)
@@ -68,7 +65,7 @@ def base64_enc(b):
 # @param CA which signing CA to use
 # @return the certificate in PEM format
 # @note algorithm and parts of the code are from acme-tiny
-def get_crt_from_csr(account_key_file, csr, domains, acme_dir, CA=DEFAULT_CA):
+def get_crt_from_csr(account_key_file, csr, domains, acme_dir, CA):
 	print("Reading account key...")
 	with open(account_key_file) as f:
 		account_key_data = f.read()


### PR DESCRIPTION
The ACME authority is no longer set in the code, but as a configuration option in the acme.conf
Also fixes a race condition