### PR TITLE
Fix setup description content type and configurable agreement

### DIFF
--- a/acertmgr/__init__.py
+++ b/acertmgr/__init__.py
@@ -42,7 +42,7 @@ def create_authority(settings):
 
     authority_module = importlib.import_module("acertmgr.authority.{0}".format(settings["api"]))
     authority_class = getattr(authority_module, "ACMEAuthority")
-    return authority_class(settings['authority'], acc_key)
+    return authority_class(settings)
 
 
 # @brief create a challenge handler for the given configuration

--- a/acertmgr/authority/acme.py
+++ b/acertmgr/authority/acme.py
@@ -9,11 +9,9 @@
 
 class ACMEAuthority:
     # @brief Init class with config
-    # @param ca Certificate authority uri
-    # @param account_key Account key file
-    def __init__(self, ca, key):
-        self.ca = ca
-        self.key = key
+    # @param config Configuration data
+    def __init__(self, config):
+        self.config = config
 
     # @brief register an account over ACME
     # @param account_key the account key to register

--- a/acertmgr/authority/v1.py
+++ b/acertmgr/authority/v1.py
@@ -29,6 +29,14 @@ from acertmgr.authority.acme import ACMEAuthority as AbstractACMEAuthority
 
 
 class ACMEAuthority(AbstractACMEAuthority):
+    # @brief Init class with config
+    # @param config Configuration data
+    def __init__(self, config):
+        AbstractACMEAuthority.__init__(self, config)
+        self.ca = config['authority']
+        self.agreement = config['authority_agreement']
+        self.key = config['account_key']
+
     # @brief create the header information for ACME communication
     # @param key the account key
     # @return the header for ACME
@@ -74,7 +82,7 @@ class ACMEAuthority(AbstractACMEAuthority):
         header = self._prepare_header()
         code, result = self._send_signed(self.ca + "/acme/new-reg", header, {
             "resource": "new-reg",
-            "agreement": "https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf",
+            "agreement": self.agreement,
         })
         if code == 201:
             print("Registered!")

--- a/acertmgr/configuration.py
+++ b/acertmgr/configuration.py
@@ -24,6 +24,7 @@ DEFAULT_KEY_LENGTH = 4096  # bits
 DEFAULT_TTL = 15  # days
 DEFAULT_API = "v1"
 DEFAULT_AUTHORITY = "https://acme-v01.api.letsencrypt.org"
+DEFAULT_AUTHORITY_AGREEMENT = "https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf"
 
 
 # @brief augment configuration with defaults
@@ -68,6 +69,13 @@ def parse_config_entry(entry, globalconfig, work_dir):
         config['authority'] = authorities[0]
     else:
         config['authority'] = globalconfig.get('authority', DEFAULT_AUTHORITY)
+
+    # Certificate authority agreement
+    authority_agreements = [x for x in entry if 'authority_agreement' in x]
+    if len(authority_agreements) > 0:
+        config['authority_agreement'] = authority_agreements[0]
+    else:
+        config['authority_agreement'] = globalconfig.get('authority_agreement', DEFAULT_AUTHORITY_AGREEMENT)
 
     # Account key
     acc_keys = [x for x in entry if 'account_key' in x]

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     url="https://github.com/moepman/acertmgr",
     packages=find_packages(),
     long_description=read('README.md'),
+    long_description_content_type="text/markdown",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: ISC License",


### PR DESCRIPTION
- Set setup.py long_description content type to markdown
- Remove the hardcoded API agreement data and make it configurable through the configuration