### PR TITLE
Fix possible invalid nonce in cache

### DIFF
--- a/acertmgr/authority/v2.py
+++ b/acertmgr/authority/v2.py
@@ -97,8 +97,11 @@ class ACMEAuthority(AbstractACMEAuthority):
         # Request a new nonce if there is none in cache
         if not self.nonce:
             self._request_url(self.directory['newNonce'])
-
+        # Set request nonce to current cache value
         protected["nonce"] = self.nonce
+        # Reset nonce cache as we are using it's current value
+        self.nonce = None
+
         protected["url"] = url
         if self.algorithm:
             protected["alg"] = self.algorithm

--- a/acertmgr/authority/v2.py
+++ b/acertmgr/authority/v2.py
@@ -208,11 +208,11 @@ class ACMEAuthority(AbstractACMEAuthority):
                         time.sleep(5)
                         code, challenge_status, _ = self._request_acme_url(authorization['_challenge']['url'])
 
-                    if challenge_status.get('status') == "valid":
+                    if code < 400 and challenge_status.get('status') == "valid":
                         log("{0} verified".format(authorization['_domain']))
                     else:
-                        raise ValueError("{0} challenge did not pass: {1}".format(
-                            authorization['_domain'], challenge_status))
+                        raise ValueError("{0} challenge did not pass ({1}): {2}".format(
+                            authorization['_domain'], code, challenge_status))
                 finally:
                     challenge_handlers[authorization['_domain']].stop_challenge(authorization['identifier']['value'],
                                                                                 account_thumbprint,


### PR DESCRIPTION
After a nonce was used in a request the cache wasn't properly cleared, which could result in an invalid second usage of the given nonce. This is resolved in this commit as well as a minor issue with correctly displaying the correlating error during challenge-status checking (which failed as expected but did not give the correct error message).  Fixes #38.