### PR TITLE
Remove legacy configuration options

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+image: ubuntu1804
+
+install:
+- sudo apt -o Dpkg::Progress-Fancy="0" install -y python3 python3-stdeb python3-setuptools debhelper fakeroot
+
+test_script:
+- python3 setup.py --command-packages=stdeb.command bdist_deb 
+
+after_test:
+- mv -v deb_dist/python3-acertmgr*.deb .
+
+artifacts:
+- path: "python3-acertmgr*.deb"
+  name: python3-acertmgr
+
+build: off


### PR DESCRIPTION
This removes all legacy configuration directives from the parser for the 1.0 release.