### PR TITLE
acertmgr/v2: Handle CA certificate chains properly (Fixes #53)

### DIFF
--- a/acertmgr/authority/v2.py
+++ b/acertmgr/authority/v2.py
@@ -260,8 +260,8 @@ class ACMEAuthority(AbstractACMEAuthority):
         if code >= 400:
             raise ValueError("Error downloading certificate chain: {0} {1}".format(code, certificate))
 
-        cert_dict = re.match((r'(?P<cert>-----BEGIN CERTIFICATE-----[^\-]+-----END CERTIFICATE-----)\n\n'
-                              r'(?P<ca>-----BEGIN CERTIFICATE-----[^\-]+-----END CERTIFICATE-----)?'),
+        cert_dict = re.match((r'(?P<cert>^-----BEGIN CERTIFICATE-----\n[^\-]+\n-----END CERTIFICATE-----)\n*'
+                              r'(?P<ca>-----BEGIN CERTIFICATE-----\n.+\n-----END CERTIFICATE-----)?$'),
                              certificate, re.DOTALL).groupdict()
         cert = tools.convert_pem_str_to_cert(cert_dict['cert'])
         if cert_dict['ca'] is None:


### PR DESCRIPTION
This fixes the way we parse CA certificates on ACMEv2.
Tool functions have been updated, so that they can handle certificate chains for CA certificates (but nothing else).

Fixes #53 