### PR TITLE
certs already contain idna domain names

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 ------------
 
   * Python (2.7+ and 3.5+ should work)
-  * cryptography>=0.6 (usually includes the optional idna module)
+  * cryptography>=2.1 (older versions break idna handling)
 
 Optional requirements (to use specified features)
 ------------------------------------------------------

--- a/acertmgr/tools.py
+++ b/acertmgr/tools.py
@@ -243,8 +243,7 @@ def get_cert_domains(cert):
     if san_cert:
         for d in san_cert.value:
             domains.add(d.value)
-    # Convert IDNA domain to correct representation and return the list
-    return [x for x, _ in idna_convert(domains)]
+    return domains
 
 
 # @brief determine certificate cn


### PR DESCRIPTION
The idna_convert call here does nothing: when reading a certificate, it
already contains idna domain names. Converting them to idna is
equivalent to the identity function, and can thus be removed.