### PR TITLE
configuration: Simplify too complex IDNA conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 ------------
 
   * Python (2.7+ and 3.5+ should work)
-  * cryptography>=2.1 (older versions break idna handling)
+  * cryptography>=0.6
 
 Optional requirements (to use specified features)
 ------------------------------------------------------

--- a/acertmgr/tools.py
+++ b/acertmgr/tools.py
@@ -384,26 +384,19 @@ def target_is_current(target, file):
     return target_date >= crt_date
 
 
-# @brief convert domain list to idna representation (if applicable
-def idna_convert(domainlist):
-    if any(ord(c) >= 128 for c in ''.join(domainlist)):
-        try:
-            domaintranslation = list()
-            for domain in domainlist:
-                if any(ord(c) >= 128 for c in domain):
-                    # Translate IDNA domain name from a unicode domain (handle wildcards separately)
-                    if domain.startswith('*.'):
-                        idna_domain = "*.{}".format(domain[2:].encode('idna').decode('ascii'))
-                    else:
-                        idna_domain = domain.encode('idna').decode('ascii')
-                    result = idna_domain, domain
-                else:
-                    result = domain, domain
-                domaintranslation.append(result)
-            return domaintranslation
-        except Exception as e:
-            log("Unicode domain(s) found but IDNA names could not be translated due to error: {}".format(e), error=True)
-    return [(x, x) for x in domainlist]
+# @brief convert domain to idna representation (if applicable
+def idna_convert(domain):
+    try:
+        if any(ord(c) >= 128 for c in domain):
+            # Translate IDNA domain name from a unicode domain (handle wildcards separately)
+            if domain.startswith('*.'):
+                idna_domain = "*.{}".format(domain[2:].encode('idna').decode('ascii'))
+            else:
+                idna_domain = domain.encode('idna').decode('ascii')
+            return idna_domain
+    except Exception as e:
+        log("Unicode domain(s) found but IDNA names could not be translated due to error: {}".format(e), error=True)
+    return domain
 
 
 # @brief validate the OCSP status for a given certificate by the given issuer


### PR DESCRIPTION
This is a prestage of @davidklaftenegger 's changes in PR #55 
 
The intent is to simplify the far too complex IDNA conversion process while maintaining all current requirements the way they are. This can be picked up by PR #55 for further changes if those are still needed.

Also will be used by a follow up PR that appends the human name to IDNA domains in log messages (in brackets or similar).