### PR TITLE
replace outdated interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 ------------
 
   * Python (2.7+ and 3.5+ should work)
-  * cryptography>=0.6
+  * cryptography>=42.0.0
 
 Optional requirements (to use specified features)
 ------------------------------------------------------

--- a/acertmgr/tools.py
+++ b/acertmgr/tools.py
@@ -92,12 +92,12 @@ def get_url(url, data=None, headers=None):
 # @param ttl_days the minimum amount of days for which the certificate must be valid
 # @return True if certificate is still valid for at least ttl_days, False otherwise
 def is_cert_valid(cert, ttl_days):
-    now = datetime.datetime.now()
-    if cert.not_valid_before > now:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    if cert.not_valid_before_utc > now:
         raise InvalidCertificateError("Certificate seems to be from the future")
 
     expiry_limit = now + datetime.timedelta(days=ttl_days)
-    if cert.not_valid_after < expiry_limit:
+    if cert.not_valid_after_utc < expiry_limit:
         return False
 
     return True


### PR DESCRIPTION
cryptography-42.0.0 introduces new interfaces to query certificate lifetime. The only difference is that the UTC timezone is set in the datetime object, instead of the timezone being undefined. However, the old interface now prints deprecation warnings.